### PR TITLE
Fix parse error for error lines with "eval()'d code" in them

### DIFF
--- a/src/Falsum/Run.php
+++ b/src/Falsum/Run.php
@@ -78,7 +78,7 @@ class Run {
 				$errors[$key]=[];
 			$errors[$key]['line']=str_replace(':','',$line[0][0]);
 			$errors[$key]['file']=
-				str_replace(':'.$errors[$key]['line'],'',$result);
+				preg_replace("/(:".$errors[$key]['line']."|\(\d+\) : eval\(\)\'d code:".$errors[$key]['line'].")/",'',$result);
 
 			$eol='';
 			$line=$errors[$key]['line']-1;


### PR DESCRIPTION
Used twig in a project, when it would error out, a blank page was returned. Turns out it wasn't fully getting the path properly because it had the string "(123) eval()'d code:456" in it. Just helping to parse it better.